### PR TITLE
Fixing error serialization on FacebookLoginResult.toMap()

### DIFF
--- a/lib/src/models/facebook_login_result.dart
+++ b/lib/src/models/facebook_login_result.dart
@@ -28,7 +28,7 @@ class FacebookLoginResult {
     return <String, dynamic>{
       'status': status.toString().split('.').last,
       'accessToken': accessToken,
-      'error': accessToken?.toMap(),
+      'error': error?.toMap(),
     };
   }
 


### PR DESCRIPTION
Just a typo.