### PR TITLE
Enabling Express Login

### DIFF
--- a/android/src/main/java/ru/innim/flutter_login_facebook/MethodCallHandler.java
+++ b/android/src/main/java/ru/innim/flutter_login_facebook/MethodCallHandler.java
@@ -9,6 +9,7 @@ import com.facebook.FacebookRequestError;
 import com.facebook.FacebookSdk;
 import com.facebook.GraphRequest;
 import com.facebook.GraphResponse;
+import com.facebook.LoginStatusCallback;
 import com.facebook.Profile;
 import com.facebook.login.LoginManager;
 
@@ -23,6 +24,7 @@ import io.flutter.plugin.common.MethodChannel.Result;
 public class MethodCallHandler implements MethodChannel.MethodCallHandler {
     private final static String _LOGIN_METHOD = "logIn";
     private final static String _LOGOUT_METHOD = "logOut";
+    private final static String _EXPRESS_LOGIN_METHOD = "expressLogin";
     private final static String _GET_ACCESS_TOKEN = "getAccessToken";
     private final static String _GET_USER_PROFILE = "getUserProfile";
     private final static String _GET_SDK_VERSION = "getSdkVersion";
@@ -51,6 +53,9 @@ public class MethodCallHandler implements MethodChannel.MethodCallHandler {
                 case _LOGIN_METHOD:
                     final List<String> permissions = call.argument(_PERMISSIONS_ARG);
                     logIn(permissions, result);
+                    break;
+                case _EXPRESS_LOGIN_METHOD:
+                    expressLogin(result);
                     break;
                 case _LOGOUT_METHOD:
                     logOut(result);
@@ -87,6 +92,23 @@ public class MethodCallHandler implements MethodChannel.MethodCallHandler {
     private void logIn(List<String> permissions, Result result) {
         _loginCallback.addPending(result);
         LoginManager.getInstance().logIn(_activity, permissions);
+    }
+
+    private void expressLogin(final Result result) {
+        LoginManager.getInstance().retrieveLoginStatus(_activity.getApplicationContext(), new LoginStatusCallback() {
+            @Override
+            public void onCompleted(AccessToken token) {
+                result.success(Results.loginSuccess(token));
+            }
+            @Override
+            public void onFailure() {
+                result.success(Results.loginCancel());
+            }
+            @Override
+            public void onError(Exception exception) {
+                result.success(Results.loginCancel());
+            }
+        });
     }
 
     private void logOut(Result result) {

--- a/android/src/main/java/ru/innim/flutter_login_facebook/MethodCallHandler.java
+++ b/android/src/main/java/ru/innim/flutter_login_facebook/MethodCallHandler.java
@@ -105,8 +105,8 @@ public class MethodCallHandler implements MethodChannel.MethodCallHandler {
                 result.success(Results.loginCancel());
             }
             @Override
-            public void onError(Exception exception) {
-                result.success(Results.loginCancel());
+            public void onError(Exception e) {
+                result.error(ErrorCode.FAILED, e.getMessage(), null);
             }
         });
     }

--- a/android/src/main/java/ru/innim/flutter_login_facebook/Results.java
+++ b/android/src/main/java/ru/innim/flutter_login_facebook/Results.java
@@ -22,6 +22,13 @@ public class Results {
         }};
     }
 
+    public static HashMap<String, Object> loginSuccess(final AccessToken accessToken) {
+        return new HashMap<String, Object>() {{
+            put("status", LoginStatus.Success.name());
+            put("accessToken", accessToken(accessToken));
+        }};
+    }
+
     public static HashMap<String, Object> loginCancel() {
         return new HashMap<String, Object>() {{
             put("status", LoginStatus.Cancel.name());

--- a/android/src/main/java/ru/innim/flutter_login_facebook/Results.java
+++ b/android/src/main/java/ru/innim/flutter_login_facebook/Results.java
@@ -16,10 +16,7 @@ public class Results {
     }
 
     public static HashMap<String, Object> loginSuccess(final LoginResult result) {
-        return new HashMap<String, Object>() {{
-            put("status", LoginStatus.Success.name());
-            put("accessToken", accessToken(result.getAccessToken()));
-        }};
+        return loginSuccess(result.getAccessToken());
     }
 
     public static HashMap<String, Object> loginSuccess(final AccessToken accessToken) {

--- a/ios/Classes/SwiftFlutterLoginFacebookPlugin.swift
+++ b/ios/Classes/SwiftFlutterLoginFacebookPlugin.swift
@@ -5,7 +5,7 @@ import FBSDKLoginKit
 
 /// Plugin methods.
 enum PluginMethod: String {
-    case logIn, logOut, expressLogin, getAccessToken, getUserProfile, getUserEmail, getSdkVersion, getProfileImageUrl
+    case logIn, logOut, getAccessToken, getUserProfile, getUserEmail, getSdkVersion, getProfileImageUrl
 }
 
 /// Arguments for method `PluginMethod.logIn`
@@ -49,8 +49,6 @@ public class SwiftFlutterLoginFacebookPlugin: NSObject, FlutterPlugin {
             
             let permissions = permissionsArg.map {val in Permission(stringLiteral: val)}
             logIn(result: result, permissions: permissions)
-        case .expressLogin:
-            expressLogin(result: result)
         case .logOut:
             logOut(result: result)
         case .getAccessToken:
@@ -229,14 +227,6 @@ public class SwiftFlutterLoginFacebookPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    private func expressLogin(result: @escaping FlutterResult) {
-        let data: [String: Any?] = [
-            "status": "Cancel",
-            "accessToken": nil,
-            "error": nil
-        ]
-        result(data)
-    }
     private func logOut(result: @escaping FlutterResult) {
         if isLoggedIn {
             _loginManager.logOut()

--- a/ios/Classes/SwiftFlutterLoginFacebookPlugin.swift
+++ b/ios/Classes/SwiftFlutterLoginFacebookPlugin.swift
@@ -5,7 +5,7 @@ import FBSDKLoginKit
 
 /// Plugin methods.
 enum PluginMethod: String {
-    case logIn, logOut, getAccessToken, getUserProfile, getUserEmail, getSdkVersion, getProfileImageUrl
+    case logIn, logOut, expressLogin, getAccessToken, getUserProfile, getUserEmail, getSdkVersion, getProfileImageUrl
 }
 
 /// Arguments for method `PluginMethod.logIn`
@@ -49,6 +49,8 @@ public class SwiftFlutterLoginFacebookPlugin: NSObject, FlutterPlugin {
             
             let permissions = permissionsArg.map {val in Permission(stringLiteral: val)}
             logIn(result: result, permissions: permissions)
+        case .expressLogin:
+            expressLogin(result: result)
         case .logOut:
             logOut(result: result)
         case .getAccessToken:
@@ -227,6 +229,14 @@ public class SwiftFlutterLoginFacebookPlugin: NSObject, FlutterPlugin {
         }
     }
     
+    private func expressLogin(result: @escaping FlutterResult) {
+        let data: [String: Any?] = [
+            "status": "Cancel",
+            "accessToken": nil,
+            "error": nil
+        ]
+        result(data)
+    }
     private func logOut(result: @escaping FlutterResult) {
         if isLoggedIn {
             _loginManager.logOut()

--- a/lib/src/facebook_login.dart
+++ b/lib/src/facebook_login.dart
@@ -7,6 +7,7 @@ import 'package:flutter_login_facebook/src/models/facebook_permission.dart';
 class FacebookLogin {
   // Methods
   static const _methodLogIn = "logIn";
+  static const _methodExpressLogIn = "expressLogin";
   static const _methodLogOut = "logOut";
   static const _methodGetAccessToken = "getAccessToken";
   static const _methodGetUserProfile = "getUserProfile";
@@ -153,6 +154,14 @@ class FacebookLogin {
     final Map<dynamic, dynamic> loginResultData = await _channel
         .invokeMethod(_methodLogIn, {_permissionsArg: permissionsArg});
 
+    if (debug) _log('Result: $loginResultData');
+    return FacebookLoginResult.fromMap(loginResultData.cast<String, dynamic>());
+  }
+
+  Future<FacebookLoginResult> expressLogin() async {
+    if (debug) _log('Trying to expressLogin');
+    final Map<dynamic, dynamic> loginResultData =
+        await _channel.invokeMethod(_methodExpressLogIn);
     if (debug) _log('Result: $loginResultData');
     return FacebookLoginResult.fromMap(loginResultData.cast<String, dynamic>());
   }

--- a/lib/src/facebook_login.dart
+++ b/lib/src/facebook_login.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_login_facebook/flutter_login_facebook.dart';
@@ -158,7 +160,16 @@ class FacebookLogin {
     return FacebookLoginResult.fromMap(loginResultData.cast<String, dynamic>());
   }
 
+  /// Start Express log in Facebook process
+  ///
+  /// Express Login is an **[Android only option](https://developers.facebook.com/docs/facebook-login/android/#expresslogin)**
+  ///
+  /// If Login is successful, returns [FacebookLoginResult] with Success Status.
+  /// ```
+  /// var fbUser = await FacebookLogin().expressLogin();
+  /// ```
   Future<FacebookLoginResult> expressLogin() async {
+    assert(Platform.isAndroid);
     if (debug) _log('Trying to expressLogin');
     final Map<dynamic, dynamic> loginResultData =
         await _channel.invokeMethod(_methodExpressLogIn);


### PR DESCRIPTION
*Description of changes:*
This is a non-breaking change.

Just giving developers the chance to authenticate the user automatically if user already was logged into the app.

Just call `FacebookLogin().expressLogin()` and it will return  a `FacebookLoginResult` just like it does when user clicks the button.

Android only for now (It depends on Facebook's iOS SDK), on iOS i've made it so it always returns "cancel" instead of "error" or "not implemented" but IMHO Users should have a logic inside their app to use it only on Android.

Documentation:
https://developers.facebook.com/docs/facebook-login/android/#expresslogin