### PR TITLE
Upgrade to Facebook SDK 9.1.

### DIFF
--- a/ios/flutter_login_facebook.podspec
+++ b/ios/flutter_login_facebook.podspec
@@ -15,7 +15,7 @@ Login via Facebook for Flutter projects.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'FBSDKLoginKit', '~> 9.0'
+  s.dependency 'FBSDKLoginKit', '~> 9.1'
   s.platform = :ios
   s.ios.deployment_target = '9.0'
 


### PR DESCRIPTION
Facebook SDK 9.0 update broke AppEvents on iOS. In version 9.1 the correct behavior has been restored.

FB SDK release notes for version 9.1:
https://github.com/facebook/facebook-ios-sdk/blob/master/CHANGELOG.md?fbclid=IwAR137y7cEsRrHZ8pvbfQTWXij5kr6T1jGBbCPR1GCtlYMytIQz5Nvpc3B8k

*Fixed:* `App Events use the correct token if none have been provided manually`