### PR TITLE
Prevent millisecondsSinceEpoch Invalid value: Not in inclusive range - error on high Facebook API expiry responses

### DIFF
--- a/lib/src/models/facebook_access_token.dart
+++ b/lib/src/models/facebook_access_token.dart
@@ -11,7 +11,10 @@ class FacebookAccessToken {
   FacebookAccessToken.fromMap(Map<String, dynamic> map)
       : token = map['token'] as String,
         userId = map['userId'] as String,
-        expires = DateTime.fromMillisecondsSinceEpoch(map['expires'] as int,
+        expires = DateTime.fromMillisecondsSinceEpoch(
+            map['expires'] as int > 8640000000000000
+                ? 8640000000000000
+                : map['expires'] as int,
             isUtc: true),
         permissions = (map['permissions'] as List).cast<String>(),
         declinedPermissions =


### PR DESCRIPTION
In some situations on Android (e.g. Pixel 3 with Android 12 and the latest Update to Facebook SDK 12 from this plugin) I had occasions in which the Facebook API would somehow return extremely high expiry timestamps (e.g. literally 9223372036854775807) when calling their `getCurrentAccessToken()`. Super weird, but this response of FB would make my app crash as the Dart `DateTime.fromMillisecondsSinceEpoch()` function has a max input value of `8640000000000000`. _Of course, when try/catching this, it would assume I was not logged in, and therefore not able to use the Facebook integration._

Therefore, I added a check/safeguard to make parsing the Facebook response more resilient. Thus, in case the Facebook API returns crazy high values like above, it will be using the max for parsing to the Dart FacebookAccessToken and prevent the `millisecondsSinceEpoch Invalid value: Not in inclusive range` error.