### PR TITLE
Add business_management permission

### DIFF
--- a/lib/src/models/facebook_permission.dart
+++ b/lib/src/models/facebook_permission.dart
@@ -132,6 +132,9 @@ enum FacebookPermission {
 
   /// Allows you to publish content to a person's Instagram feed as the person.
   instagramContentPublish
+
+  /// Allows your app to read and write with the Business Manager API.
+  businessManagement
 }
 
 extension FacebookPermissionExtension on FacebookPermission {
@@ -182,4 +185,5 @@ final _mapToString = {
   FacebookPermission.adsRead: 'ads_read',
   FacebookPermission.instagramBasic: 'instagram_basic',
   FacebookPermission.instagramContentPublish: 'instagram_content_publish',
+  FacebookPermission.businessManagement: 'business_management'
 };


### PR DESCRIPTION
The package does not have the `business_management` permission that is needed to read and write with the Business Manager API. As this permission is required to fetch all pages, also the ones managed through a business manager see issue at  https://developers.facebook.com/support/bugs/780004130341035 I have added it to repair our app.