### PR TITLE
Update flutter_login_facebook.podspec to fix conflict with facebook_app_events 0.19.2

### DIFF
--- a/ios/flutter_login_facebook.podspec
+++ b/ios/flutter_login_facebook.podspec
@@ -15,7 +15,7 @@ Login via Facebook for Flutter projects.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'FBSDKLoginKit', '16.2.1'
+  s.dependency 'FBSDKLoginKit', '~> 17.0'
   s.platform = :ios
   s.ios.deployment_target = '12.0'
 


### PR DESCRIPTION
to fix the following build error:

[!] CocoaPods could not find compatible versions for pod "FBSDKCoreKit":
      In Podfile:
        facebook_app_events (from `.symlinks/plugins/facebook_app_events/ios`) was resolved to 0.0.1, which depends on
          FBSDKCoreKit (~> 17.0)
        flutter_login_facebook (from `.symlinks/plugins/flutter_login_facebook/ios`) was resolved to 1.9.0, which depends on
          FBSDKLoginKit (= 16.2.1) was resolved to 16.2.1, which depends on
            FBSDKCoreKit (= 16.2.1)