### PR TITLE
Fix compileSdkVersion on newer flutter 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,9 +21,13 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-android {
-    compileSdkVersion 28
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
+android {
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Make a non-breaking change to ensure compatibility with the newer Flutter version and enable our app to build successfully.

in Android/build.gradle add:
```

ext {
    compileSdkVersion   = 34
}
```